### PR TITLE
Add toggle to disable / enable mobile touch

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ const component = (
 | startupScreen       |   `node`   |      `null`      | Set's the startup screen component to be shown before the first screen is loaded. It works like a pre-loading screen.                                |
 | startup             | `boolean`  |      `true`      | Used together with `startupScreen` controls whether or not the startupScreen should auto-start.                                                      |
 | transitionDelay     |  `number`  |       `0`        | Sets a delay in `ms` between the slide transitions. Useful if you're waiting for an exit animation to finish in the current slide.                   |
-| touch               | `boolean`  |      `true`      | When set to true activates a swipe touch effect to navigate on mobile devices.                                                                        |
+| mobileTouch         | `boolean`  |      `true`      | When set to true activates a swipe touch effect to navigate on mobile devices.                                                                        |
 | buttons             | `boolean`  |      `true`      | Should render the default left and right navigation buttons.                                                                                         |
 | buttonContentRight  |   `node`   |      `null`      | Add content as children of the right button.                                                                                                         |
 | buttonContentLeft   |   `node`   |      `null`      | Add content as children of the left button.                                                                                                          |

--- a/README.md
+++ b/README.md
@@ -227,6 +227,7 @@ const component = (
 | startupScreen       |   `node`   |      `null`      | Set's the startup screen component to be shown before the first screen is loaded. It works like a pre-loading screen.                                |
 | startup             | `boolean`  |      `true`      | Used together with `startupScreen` controls whether or not the startupScreen should auto-start.                                                      |
 | transitionDelay     |  `number`  |       `0`        | Sets a delay in `ms` between the slide transitions. Useful if you're waiting for an exit animation to finish in the current slide.                   |
+| touch               | `boolean`  |      `true`      | When set to true activates a swipe touch effect to navigate on mobile devices.                                                                        |
 | buttons             | `boolean`  |      `true`      | Should render the default left and right navigation buttons.                                                                                         |
 | buttonContentRight  |   `node`   |      `null`      | Add content as children of the right button.                                                                                                         |
 | buttonContentLeft   |   `node`   |      `null`      | Add content as children of the left button.                                                                                                          |

--- a/index.d.ts
+++ b/index.d.ts
@@ -55,6 +55,7 @@ declare module 'react-awesome-slider' {
     startupScreen?: object;
     style?: object;
     transitionDelay?: number;
+    touch?: boolean;
   }
 
   export default class AwesomeSlider extends Component<

--- a/index.d.ts
+++ b/index.d.ts
@@ -55,7 +55,7 @@ declare module 'react-awesome-slider' {
     startupScreen?: object;
     style?: object;
     transitionDelay?: number;
-    touch?: boolean;
+    mobileTouch?: boolean;
   }
 
   export default class AwesomeSlider extends Component<

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -909,6 +909,27 @@ export default class AwesomeSlider extends React.Component {
     );
   };
 
+  renderBox(box, mobileTouch) {	
+    return (	
+      <div	
+        ref={el => {	
+          this[`box${box}`] = el;	
+        }}	
+        className={this.classNames.box}	
+        onTouchStart={mobileTouch ? this.touchStart : undefined}	
+        onTouchMove={mobileTouch ? this.touchMove : undefined}	
+        onTouchEnd={mobileTouch ? this.touchEnd : undefined}	
+      >	
+        {this.state[`box${box}`] && (	
+          <Media	
+            media={this.state[`box${box}`]}	
+            className={this.classNames.content}	
+          />	
+        )}	
+      </div>	
+    );	
+  }
+
   render() {
     const {
       cssModule,
@@ -943,38 +964,8 @@ export default class AwesomeSlider extends React.Component {
             }}
             className={this.classNames.container}
           >
-            <div
-              ref={el => {
-                this.boxA = el;
-              }}
-              className={this.classNames.box}
-              onTouchStart={mobileTouch ? this.touchStart : undefined}
-              onTouchMove={mobileTouch ? this.touchMove : undefined}
-              onTouchEnd={mobileTouch ? this.touchEnd : undefined}
-            >
-              {this.state.boxA && (
-                <Media
-                  media={this.state.boxA}
-                  className={this.classNames.content}
-                />
-              )}
-            </div>
-            <div
-              ref={el => {
-                this.boxB = el;
-              }}
-              className={this.classNames.box}
-              onTouchStart={mobileTouch ? this.touchStart : undefined}
-              onTouchMove={mobileTouch ? this.touchMove : undefined}
-              onTouchEnd={mobileTouch ? this.touchEnd : undefined}
-            >
-              {this.state.boxB && (
-                <Media
-                  media={this.state.boxB}
-                  className={this.classNames.content}
-                />
-              )}
-            </div>
+            {this.renderBox('A')}
+            {this.renderBox('B')}
           </div>
           {buttons && (
             <Buttons

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -909,25 +909,25 @@ export default class AwesomeSlider extends React.Component {
     );
   };
 
-  renderBox(box, mobileTouch) {	
-    return (	
-      <div	
-        ref={el => {	
-          this[`box${box}`] = el;	
-        }}	
-        className={this.classNames.box}	
-        onTouchStart={mobileTouch ? this.touchStart : undefined}	
-        onTouchMove={mobileTouch ? this.touchMove : undefined}	
-        onTouchEnd={mobileTouch ? this.touchEnd : undefined}	
-      >	
-        {this.state[`box${box}`] && (	
-          <Media	
-            media={this.state[`box${box}`]}	
-            className={this.classNames.content}	
-          />	
-        )}	
-      </div>	
-    );	
+  renderBox(box, mobileTouch) {
+    return (
+      <div
+        ref={el => {
+          this[`box${box}`] = el;
+        }}
+        className={this.classNames.box}
+        onTouchStart={mobileTouch ? this.touchStart : undefined}
+        onTouchMove={mobileTouch ? this.touchMove : undefined}
+        onTouchEnd={mobileTouch ? this.touchEnd : undefined}
+      >
+        {this.state[`box${box}`] && (
+          <Media
+            media={this.state[`box${box}`]}
+            className={this.classNames.content}
+          />
+        )}
+      </div>
+    );
   }
 
   render() {

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -54,6 +54,7 @@ export default class AwesomeSlider extends React.Component {
     startupScreen: PropTypes.object,
     style: PropTypes.object,
     transitionDelay: PropTypes.number,
+    touch: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -87,6 +88,7 @@ export default class AwesomeSlider extends React.Component {
     startupScreen: null,
     style: {},
     transitionDelay: 0,
+    touch: true,
   };
 
   constructor(props) {
@@ -907,27 +909,6 @@ export default class AwesomeSlider extends React.Component {
     );
   };
 
-  renderBox(box) {
-    return (
-      <div
-        ref={el => {
-          this[`box${box}`] = el;
-        }}
-        className={this.classNames.box}
-        onTouchStart={this.touchStart}
-        onTouchMove={this.touchMove}
-        onTouchEnd={this.touchEnd}
-      >
-        {this.state[`box${box}`] && (
-          <Media
-            media={this.state[`box${box}`]}
-            className={this.classNames.content}
-          />
-        )}
-      </div>
-    );
-  }
-
   render() {
     const {
       cssModule,
@@ -938,6 +919,7 @@ export default class AwesomeSlider extends React.Component {
       buttons,
       buttonContentLeft,
       buttonContentRight,
+      touch
     } = this.props;
     const { rootElement } = this;
 
@@ -961,8 +943,38 @@ export default class AwesomeSlider extends React.Component {
             }}
             className={this.classNames.container}
           >
-            {this.renderBox('A')}
-            {this.renderBox('B')}
+            <div
+              ref={el => {
+                this.boxA = el;
+              }}
+              className={this.classNames.box}
+              onTouchStart={touch ? this.touchStart : undefined}
+              onTouchMove={touch ? this.touchMove : undefined}
+              onTouchEnd={touch ? this.touchEnd : undefined}
+            >
+              {this.state.boxA && (
+                <Media
+                  media={this.state.boxA}
+                  className={this.classNames.content}
+                />
+              )}
+            </div>
+            <div
+              ref={el => {
+                this.boxB = el;
+              }}
+              className={this.classNames.box}
+              onTouchStart={touch ? this.touchStart : undefined}
+              onTouchMove={touch ? this.touchMove : undefined}
+              onTouchEnd={touch ? this.touchEnd : undefined}
+            >
+              {this.state.boxB && (
+                <Media
+                  media={this.state.boxB}
+                  className={this.classNames.content}
+                />
+              )}
+            </div>
           </div>
           {buttons && (
             <Buttons

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -54,7 +54,7 @@ export default class AwesomeSlider extends React.Component {
     startupScreen: PropTypes.object,
     style: PropTypes.object,
     transitionDelay: PropTypes.number,
-    touch: PropTypes.bool,
+    mobileTouch: PropTypes.bool,
   };
 
   static defaultProps = {
@@ -88,7 +88,7 @@ export default class AwesomeSlider extends React.Component {
     startupScreen: null,
     style: {},
     transitionDelay: 0,
-    touch: true,
+    mobileTouch: true,
   };
 
   constructor(props) {
@@ -919,7 +919,7 @@ export default class AwesomeSlider extends React.Component {
       buttons,
       buttonContentLeft,
       buttonContentRight,
-      touch
+      mobileTouch
     } = this.props;
     const { rootElement } = this;
 
@@ -948,9 +948,9 @@ export default class AwesomeSlider extends React.Component {
                 this.boxA = el;
               }}
               className={this.classNames.box}
-              onTouchStart={touch ? this.touchStart : undefined}
-              onTouchMove={touch ? this.touchMove : undefined}
-              onTouchEnd={touch ? this.touchEnd : undefined}
+              onTouchStart={mobileTouch ? this.touchStart : undefined}
+              onTouchMove={mobileTouch ? this.touchMove : undefined}
+              onTouchEnd={mobileTouch ? this.touchEnd : undefined}
             >
               {this.state.boxA && (
                 <Media
@@ -964,9 +964,9 @@ export default class AwesomeSlider extends React.Component {
                 this.boxB = el;
               }}
               className={this.classNames.box}
-              onTouchStart={touch ? this.touchStart : undefined}
-              onTouchMove={touch ? this.touchMove : undefined}
-              onTouchEnd={touch ? this.touchEnd : undefined}
+              onTouchStart={mobileTouch ? this.touchStart : undefined}
+              onTouchMove={mobileTouch ? this.touchMove : undefined}
+              onTouchEnd={mobileTouch ? this.touchEnd : undefined}
             >
               {this.state.boxB && (
                 <Media

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -964,8 +964,8 @@ export default class AwesomeSlider extends React.Component {
             }}
             className={this.classNames.container}
           >
-            {this.renderBox('A')}
-            {this.renderBox('B')}
+            {this.renderBox('A', mobileTouch)}
+            {this.renderBox('B', mobileTouch)}
           </div>
           {buttons && (
             <Buttons


### PR DESCRIPTION
Hey @rcaferati, I added this small PR that adds a new prop to the component called `touch` with a default value of `true`. This boolean prop will set the status of the mobile swipe effect that advanced to the next slide.

Hit me up if you require any changes

Solves issue #100 