### PR TITLE
Updated patterns to support base64 data urls

### DIFF
--- a/src/helpers/components.js
+++ b/src/helpers/components.js
@@ -27,10 +27,10 @@ export class MediaLoader {
       this.resolve = resolve;
       this.loading = true;
       this.ended = false;
-      if (url.match(/\.(mp4|webm)/i)) {
+      if (url.match(/\.(mp4|webm)|data:video\/.*;base64,/i)) {
         this.video.setAttribute('src', url);
       }
-      if (url.match(/\.(png|jp(e)?g|gif|webp)/i)) {
+      if (url.match(/\.(png|jp(e)?g|gif|webp)|data:image\/.*;base64,/i)) {
         this.image.src = url;
         if (this.image.width > 0 || this.image.height > 0) {
           resolve(true);
@@ -70,10 +70,10 @@ export class MediaLoader {
     }
   }
   startLoad(url) {
-    if (url.match(/\.(mp4|webm)/i)) {
+    if (url.match(/\.(mp4|webm)|data:video\/.*;base64,/i)) {
       this.loadVideo(url);
     }
-    if (url.match(/\.(png|jp(e)?g|gif|webp)/i)) {
+    if (url.match(/\.(png|jp(e)?g|gif|webp)|data:image\/.*;base64,/i)) {
       this.loadImage(url);
     }
   }


### PR DESCRIPTION
I had a use case where I'm using the slider in a preview before the user uploads files to the server, so I only have base64 data urls.

The loader would just hang because it wouldn't know what to do with them when I tried to navigate to the second image in the list.

I simply updated the pattern matching to understand the base64's prefix in addition to the file extensions it already supported.