### PR TITLE
Force muted attribute to render for videos

### DIFF
--- a/src/core/media.js
+++ b/src/core/media.js
@@ -49,7 +49,7 @@ export default class Media extends React.Component {
                 autoplay
                 playsinline
                 preload="metadata"
-              />
+              />`
             }}
           />
         );

--- a/src/core/media.js
+++ b/src/core/media.js
@@ -32,11 +32,25 @@ export default class Media extends React.Component {
     if (source) {
       if (source.match(/\.(mp4|webm)/)) {
         background = (
-          <video
-            title={media.title || media[`data-title`]}
-            src={source}
-            type="video/mp4"
-            controls
+//           <video
+//             title={media.title || media[`data-title`]}
+//             src={source}
+//             type="video/mp4"
+//             controls
+//           />
+          <div
+            dangerouslySetInnerHTML={{
+              __html: `
+              <video
+                title="${ media.title || media[`data-title`] }"
+                src="${source}"
+                loop
+                muted
+                autoplay
+                playsinline
+                preload="metadata"
+              />
+            }}
           />
         );
       } else {


### PR DESCRIPTION
In order to autoplay Video on mobile devices, the muted option needs to be set by default.